### PR TITLE
Add missing README docs for action directories

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,5 @@
+# Alembic Deploy Action
+
+Safely applies Alembic migrations to a target database. Supports optional backups and multi-database deployments.
+
+Configuration options are documented in [`action.yaml`](./action.yaml).

--- a/review/README.md
+++ b/review/README.md
@@ -1,0 +1,5 @@
+# Alembic Review Action
+
+This action checks for Alembic migrations in a pull request and generates the corresponding SQL statements. The SQL is then posted as a comment on the pull request to help reviewers understand the database changes.
+
+See [`action.yaml`](./action.yaml) for a full list of inputs and steps.

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,5 @@
+# Alembic Test Action
+
+Runs migrations against a test database to ensure they apply cleanly and can be rolled back. Optionally loads test data for more comprehensive verification.
+
+See [`action.yaml`](./action.yaml) for configuration details.


### PR DESCRIPTION
## Summary
- add READMEs for `review/`, `test/`, and `deploy/`